### PR TITLE
update openSSL command

### DIFF
--- a/src/dotenv-vault.sh
+++ b/src/dotenv-vault.sh
@@ -54,7 +54,7 @@ dotenv-vault::encrypt-file() {
         if dotenv-vault::should-encrypt $key $pattern; then
             echo "$key=$value"
         else
-            value=`echo $value | openssl aes-256-cbc -A -base64 -k $password -e`
+            value=`echo $value | openssl aes-256-cbc -A -base64 -md sha512 -pbkdf2 -iter 100000 -pass pass:$password -e`
             echo "$key=$value"
         fi
     done
@@ -72,7 +72,7 @@ dotenv-vault::decrypt-file() {
         if dotenv-vault::should-encrypt $key $pattern; then
             echo "$key=$value"
         else
-            value=`echo $value | openssl aes-256-cbc -A -base64 -k $password -d`
+            value=`echo $value | openssl aes-256-cbc -A -base64 -md sha512 -pbkdf2 -iter 100000 -pass pass:$password -d`
             echo "$key=$value"
         fi
     done
@@ -86,7 +86,7 @@ dotenv-vault::create() {
     fi
     key=`dotenv-vault::get-key-from-line $target`
     value=`dotenv-vault::get-value-from-line $target`
-    encrypted_value=`echo $value | openssl aes-256-cbc -A -base64 -k $password -e`
+    encrypted_value=`echo $value | openssl aes-256-cbc -A -base64 -md sha512 -pbkdf2 -iter 100000 -pass pass:$password -e`
     echo "$key=$encrypted_value"
 }
 


### PR DESCRIPTION
There have been a couple changes to openSSL in the last few years. The command currently used now produces warnings when run with the latest version of openSSL. This PR updates the command per:

- https://wiki.openssl.org/index.php/Enc
- https://askubuntu.com/questions/1093591/how-should-i-change-encryption-according-to-warning-deprecated-key-derivat

to remove warnings and provide increased security via more rounds of encryption.

This PR maintains all backwards compatibility.